### PR TITLE
Add jupyterlab-favorites to default env for 159

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -41,6 +41,7 @@ dependencies:
   - jupyter_bokeh=3.0.4
   - jupyterlab=3.2.9
   - jupyterlab-drawio=0.9.0
+  - jupyterlab-favorites=3.0.0
   - jupyterlab-geojson=3.2.0
   - jupyterlab-git=0.34.2
   - jupyterlab-link-share==0.2.4


### PR DESCRIPTION
This is a minor but very useful convenience for the class, I suspect other hubs might like it too.

Note - this replicates b1951683 in the main datahub repo, doing it here to test the waters of the new system.